### PR TITLE
Make business email reusable across tests

### DIFF
--- a/cypress/e2e/optional.cy.js
+++ b/cypress/e2e/optional.cy.js
@@ -9,7 +9,7 @@ describe('Sign up Test with various how you head about us options', () => {
        
     })
 
-    it.only('business registration', () => {
+    it('business registration', () => {
         cy.fill_any_optional_field('business registration');
         cy.how_you_heard_about_us('Webinar/Seminar');
         cy.fill_in_password(password);
@@ -27,7 +27,7 @@ describe('Sign up Test with various how you head about us options', () => {
         cy.retrieve_and_insert_otp();
     })
 
-   it('instagram', () => {
+   it.skip('instagram', () => {
         cy.fill_any_optional_field('instagram');
         cy.how_you_heard_about_us('Webinar/Seminar');
         cy.fill_in_password(password);
@@ -36,7 +36,7 @@ describe('Sign up Test with various how you head about us options', () => {
         cy.retrieve_and_insert_otp();
     })
 
-   it('twitter', () => {
+   it.skip('twitter', () => {
         cy.fill_any_optional_field('twitter');
         cy.how_you_heard_about_us('Webinar/Seminar');
         cy.fill_in_password(password);

--- a/cypress/e2e/tryMimaOne.cy.js
+++ b/cypress/e2e/tryMimaOne.cy.js
@@ -9,7 +9,7 @@ describe('Sign up Test with various how you head about us options', () => {
         cy.click_button('Next');
     })
 
-    it.only('Webinar/Seminar', () => {
+    it('Webinar/Seminar', () => {
         cy.how_you_heard_about_us('Webinar/Seminar');
         cy.fill_in_password(password);
         cy.click_button('Sign Up');
@@ -25,7 +25,7 @@ describe('Sign up Test with various how you head about us options', () => {
         cy.retrieve_and_insert_otp()
     })
 
-    it('Facebook', () => {
+    it.skip('Facebook', () => {
         cy.how_you_heard_about_us('Facebook');
         cy.fill_in_password(password);
         cy.click_button('Sign Up');
@@ -33,7 +33,7 @@ describe('Sign up Test with various how you head about us options', () => {
         cy.retrieve_and_insert_otp()
     })
 
-    it('Twitter', () => {
+    it.skip('Twitter', () => {
         cy.how_you_heard_about_us('Twitter');
         cy.fill_in_password(password);
         cy.click_button('Sign Up');
@@ -41,7 +41,7 @@ describe('Sign up Test with various how you head about us options', () => {
         cy.retrieve_and_insert_otp()
     })
 
-    it('Google Search', () => {
+    it.skip('Google Search', () => {
         cy.how_you_heard_about_us('Google Search');
         cy.fill_in_password(password);
         cy.click_button('Sign Up');
@@ -49,7 +49,7 @@ describe('Sign up Test with various how you head about us options', () => {
         cy.retrieve_and_insert_otp()
     })
 
-    it('Friends & Family', () => {
+    it.skip('Friends & Family', () => {
         cy.how_you_heard_about_us('Friends & Family');
         cy.fill_in_password(password);
         cy.click_button('Sign Up');
@@ -57,7 +57,7 @@ describe('Sign up Test with various how you head about us options', () => {
         cy.retrieve_and_insert_otp()
     })
 
-    it('Mima Sales Agent', () => {
+    it.skip('Mima Sales Agent', () => {
         cy.how_you_heard_about_us('Mima Sales Agent');
         cy.fill_in_password(password);
         cy.click_button('Sign Up');
@@ -65,7 +65,7 @@ describe('Sign up Test with various how you head about us options', () => {
         cy.retrieve_and_insert_otp();
     })
 
-    it('Others', () => {
+    it.skip('Others', () => {
         cy.how_you_heard_about_us('Others');
         cy.fill_in_password(password);
         cy.click_button('Sign Up');

--- a/cypress/support/custom_commands/commonActions.js
+++ b/cypress/support/custom_commands/commonActions.js
@@ -1,5 +1,5 @@
 import { fakerEN_NG as faker } from '@faker-js/faker';
-import {JSDOM} from 'jsdom'
+import { JSDOM } from 'jsdom'
 import { html } from 'cheerio';
 import { min, max } from 'moment';
 
@@ -10,11 +10,11 @@ let emailDomain = '@maildrop.cc'
 let busReg = faker.string.numeric({ length: { min: 5, max: 7 } });
 let email
 let emailAddress
-before(()=>{
+beforeEach(() => {
     const checker = new Date().getTime()
-    const emailSuffix = checker.toString().substring(6,13);
+    const emailSuffix = checker.toString().substring(6, 13);
     const emailPrefix = `test${emailSuffix}`
-     emailAddress = `${emailPrefix}${emailDomain}`
+    emailAddress = `${emailPrefix}${emailDomain}`
     const userDetails = {
         emailAddress: emailAddress, // convert the email to a json file
         mailD: emailPrefix
@@ -22,23 +22,30 @@ before(()=>{
 
     cy.writeFile('cypress/fixtures/creds.json', JSON.stringify(userDetails, null, 2))
 
-     cy.fixture('elements').then((loc) => {
+    cy.fixture('elements').then((loc) => {
         signup = loc.signupPage
         login = loc.loginPage
     })
-    cy.fixture('creds').then((cred)=>{
+    cy.fixture('creds').then((cred) => {
         email = cred
     })
 })
 
+Cypress.Commands.add('read_email_from_file', (text) => {
+    return cy.readFile('cypress/fixtures/creds.json')
+})
 
 Cypress.Commands.add('click_button', (text) => {
     cy.get('button').contains(text).click();
 })
+Cypress.Commands.add('fill_business_email', () => {
+    cy.read_email_from_file().then((email) => {
+        cy.get(signup.businessEmailField).fill(email.emailAddress)
+    })
+})
 
 Cypress.Commands.add('click_any_element', (element) => {
     cy.get(element).click();
-    signup.button
 })
 
 Cypress.Commands.add('fill_any_input_field', (field, text) => {
@@ -54,13 +61,16 @@ Cypress.Commands.add('fill_basic_info_and_business_reg', () => {
     const input = [
         faker.person.fullName(),
         faker.company.buzzNoun(),
-        email.emailAddress,
         faker.phone.number({ style: 'international' }),
         faker.string.numeric({ length: { min: 5, max: 7 } }),
     ]
-    cy.get('input').each(($el, index) => {
-        cy.wrap($el).fill(input[index]);
-    })
+
+    cy.get(signup.fullNameField).fill(input[0])
+    cy.get(signup.businessNameField).fill(input[1])
+    cy.fill_business_email()
+    cy.get(signup.businessPhoneField).fill(input[2])
+    cy.get(signup.businessRegNumField).fill(input[3])
+
 })
 
 Cypress.Commands.add('how_you_heard_about_us', (text) => {
@@ -69,76 +79,75 @@ Cypress.Commands.add('how_you_heard_about_us', (text) => {
 })
 
 Cypress.Commands.add('retrieve_and_insert_otp', () => {
-    
+
     cy.log(email.mailD)
     cy.wait(20000);
     cy.request({
         method: "POST",
         url: "https://api.maildrop.cc/graphql",
         header: {
-                "content-type": "application/json"
+            "content-type": "application/json"
         },
         body: {
             query: `query Example { inbox(mailbox:"${email.mailD}") { id headerfrom subject data } }`,
             variable: {}
         }
-    }).then((response)=>{
-      const  inboxID = response.body.data.inbox[0].id
+    }).then((response) => {
+        const inboxID = response.body.data.inbox[0].id
 
         return cy.request({
-        method: "POST",
-        url: "https://api.maildrop.cc/graphql",
-        header: {
+            method: "POST",
+            url: "https://api.maildrop.cc/graphql",
+            header: {
                 "content-type": "application/json"
-        },
-        body: {
-            query: `query Example { 
+            },
+            body: {
+                query: `query Example { 
             message(mailbox:"${email.mailD}", id:"${inboxID}") { id headerfrom subject data html}
              }`,
-            variable: {}
-        }
-    }).then((response)=>{
-        const emailBody = response.body.data.message.html
-        const parser = new DOMParser()
-        const doc = parser.parseFromString(emailBody, 'text/html');
-        const otpCode = doc.documentElement.querySelector('center>table > tbody > tr:nth-child(2) p:nth-of-type(3)').textContent
-        const otp = otpCode.trim();
-        cy.get('input[type="tel"]').each(($el, index)=>{
-            cy.wrap($el).fill(otp[index]);
+                variable: {}
+            }
+        }).then((response) => {
+            const emailBody = response.body.data.message.html
+            const parser = new DOMParser()
+            const doc = parser.parseFromString(emailBody, 'text/html');
+            const otpCode = doc.documentElement.querySelector('center>table > tbody > tr:nth-child(2) p:nth-of-type(3)').textContent
+            const otp = otpCode.trim();
+            cy.get('input[type="tel"]').each(($el, index) => {
+                cy.wrap($el).fill(otp[index]);
+            })
         })
     })
-    })
-    
+
 })
 
 Cypress.Commands.add('fill_required_fields', () => {
     const input = [
         faker.person.fullName(),
         faker.company.buzzNoun(),
-        email.emailAddress, //faker.internet.email({ provider: 'gmail.com' }),
         faker.phone.number({ style: 'international' })
     ]
     cy.get(signup.fullNameField).fill(input[0])
     cy.get(signup.businessNameField).fill(input[1])
-    cy.get(signup.businessEmailField).fill(input[2])
-    cy.get(signup.businessPhoneField).fill(input[3])
-   
+    cy.fill_business_email()
+    cy.get(signup.businessPhoneField).fill(input[2])
+
 })
 
-Cypress.Commands.add('fill_any_optional_field', (optional)=>{
-    if(optional === 'business registration'){
+Cypress.Commands.add('fill_any_optional_field', (optional) => {
+    if (optional === 'business registration') {
         cy.fill_any_input_field(signup.businessRegNumField, busReg)
         cy.click_button('Next');
     }
-    else if(optional === 'website'){
+    else if (optional === 'website') {
         cy.click_button('Next');
         cy.fill_any_input_field(signup.websiteField, 'www.google.com')
     }
-    else if(optional === 'instagram'){
+    else if (optional === 'instagram') {
         cy.click_button('Next');
         cy.fill_any_input_field(signup.instagramField, 'Dele007')
     }
-    else if(optional === 'twitter'){
+    else if (optional === 'twitter') {
         cy.click_button('Next');
         cy.fill_any_input_field(signup.twitterField, 'Dele007')
     }


### PR DESCRIPTION
Modified the email to be reusable and re-readable always before each test. Initially,  a before hook was used to generate an email, and as we all know how before hooks works, it only run once and compile before all test begin to run making the email test data 
 static for all test even though there is a logic to generate email for all test iterations. Now the before hook has been modified to beforeEach hook   a command to compel Cypress to re-read the data before each test